### PR TITLE
Shorten to circle platforms ➊ for MTR & LRT

### DIFF
--- a/hk_bus_eta/eta.py
+++ b/hk_bus_eta/eta.py
@@ -18,7 +18,7 @@ import hashlib
 def get_platform_display(plat, lang):
     number = int(plat) if isinstance(plat, str) else plat
     if number < 0 or number > 20:
-        return f"Platform {number}" if lang == "en" else f"{number}號月台"
+        return ("Platform {}" if lang == "en" else "{}號月台").format(number)
     if number == 0:
         return "⓿"
     if number > 10:

--- a/hk_bus_eta/eta.py
+++ b/hk_bus_eta/eta.py
@@ -15,6 +15,16 @@ from datetime import datetime, timezone
 import re
 import hashlib
 
+def get_platform_display(plat, lang):
+    number = int(plat) if isinstance(plat, str) else plat
+    if number < 0 or number > 20:
+        return f"Platform {number}" if lang == "en" else f"{number}號月台"
+    if number == 0:
+        return "⓿"
+    if number > 10:
+        return chr(9451 + (number - 11))
+    return chr(10102 + (number - 1))
+
 class HKEta:
   holidays = None
   route_list = None
@@ -90,7 +100,7 @@ class HKEta:
     } for e in data]
   
   def ctb(self, stop_id, route, bound, seq):
-    data = requests.get("https://rt.data.gov.hk//v2/transport/citybus/eta/CTB/{}/{}".format(stop_id, route)).json()['data']
+    data = requests.get("https://rt.data.gov.hk/v2/transport/citybus/eta/CTB/{}/{}".format(stop_id, route)).json()['data']
     data = list(filter(lambda e: 'eta' in e and e['dir'] in bound, data))
     data.sort(key=lambda e: abs(seq - e['seq']))
     data = [e for e in data if e['seq'] == data[0]['seq']]
@@ -163,8 +173,8 @@ class HKEta:
       ret.append({
         "eta": e["time"].replace(" ", "T") + "+08:00",
         "remark": {
-          "zh": "{}號月台".format(e["plat"]),
-          "en": "Platform {}".format(e["plat"])
+          "zh": get_platform_display(e["plat"], "zh"),
+          "en": get_platform_display(e["plat"], "en")
         },
         "co": "mtr"
       })
@@ -187,8 +197,8 @@ class HKEta:
           ret.append({
             "eta": dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+08:00"),
             "remark": {
-              "zh": "{}號月台".format(platform_id),
-              "en": "Platform {}".format(platform_id)
+              "zh": get_platform_display(platform_id, "zh"),
+              "en": get_platform_display(platform_id, "en")
             },
             "co": "lightrail"
           })


### PR DESCRIPTION
Shorten platform numbers to circles for MTR & LRT as suggested in telegram. ➊

Fallback to text if there isn't a Unicode character available for that number, tho in practice it should never happen, there are no platforms -1, 21 or 9.75 in Hong Kong.

This PR has also been ported over to [JS](https://github.com/hkbus/hk-bus-eta/pull/2).