### PR TITLE
Add support to Windows & Python 3.10 environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project is to fetch the bus route information of KMB, CTB, NLB, minibus, MT
 
 ## Fetching Transport ETA
 
-The package is a python vertion for the npm package [hk-bus-eta](https://www.npmjs.com/package/hk-bus-eta).
+The package is a python version for the npm package [hk-bus-eta](https://www.npmjs.com/package/hk-bus-eta).
 
 ### Installation
 To install the package,
@@ -44,14 +44,22 @@ print( route_ids )
 ```
 
 
-## Crawling by yourself
+## Data Crawling by yourself
 
 ### Usage
 Daily fetched JSON is in [gh-pages](https://github.com/hkbus/hk-bus-crawling/tree/gh-pages) or direct download [here](https://hkbus.github.io/hk-bus-crawling/routeFareList.min.json)
 
 ### Installation
 
-To install the dependencies,
+To avoid the conflict of dependencies between python projects, it's better to create a fresh environment for this run:
+
+1. Consider to install either [Miniforge3](https://github.com/conda-forge/miniforge?tab=readme-ov-file#download), Conda or pyenv
+2. Create env: `conda create -n hkbus_crawling python=3.88 pip`
+3. Activate env: `conda activate hkbus_crawling`
+
+
+To install the dependencies to your environment:
+
 ```
 pip install -r ./crawling/requirements.txt
 ```
@@ -69,6 +77,10 @@ python ./crawling/lightRail.py
 python ./crawling/mtr.py
 python ./crawling/parseJourneyTime.py
 python ./crawling/parseGtfs.py
+python ./crawling/parseGtfsEn.py
+python ./crawling/sunferry.py
+python ./crawling/fortuneferry.py
+python ./crawling/hkkf.py
 python ./crawling/gmb.py
 python ./crawling/matchGtfs.py
 python ./crawling/cleansing.py

--- a/crawling/cleansing.py
+++ b/crawling/cleansing.py
@@ -18,7 +18,7 @@ def countBus(freq):
   return sum
 
 def cleansing(co):
-  with open('routeFareList.%s.json' % co) as f:
+  with open('routeFareList.%s.json' % co, 'r', encoding='UTF-8') as f:
     routeList = json.load(f)
   
   for i in range(len(routeList)):
@@ -44,7 +44,7 @@ def cleansing(co):
   _routeList = [route for route in routeList if 'skip' not in route]
   print (co, len(routeList), len(_routeList))
   
-  with open('routeFareList.%s.cleansed.json' % co, 'w') as f:
+  with open('routeFareList.%s.cleansed.json' % co, 'w', encoding='UTF-8') as f:
     f.write(json.dumps(_routeList, ensure_ascii=False))
   
 

--- a/crawling/ctb.py
+++ b/crawling/ctb.py
@@ -5,7 +5,7 @@ from os import path
 
 import httpx
 
-from crawling.crawl_utils import emitRequest, get_request_limit
+from crawl_utils import emitRequest, get_request_limit
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +27,7 @@ async def getRouteStop(co):
     _stops = []
     stopList = {}
     if path.isfile(STOP_LIST):
-        with open(STOP_LIST) as f:
+        with open(STOP_LIST, 'r', encoding='UTF-8') as f:
             stopList = json.load(f)
    
     # function to load single stop info
@@ -91,9 +91,9 @@ async def getRouteStop(co):
                     'serviceType': 0
                 })
 
-    with open(ROUTE_LIST, 'w') as f:
+    with open(ROUTE_LIST, 'w', encoding='UTF-8') as f:
         f.write(json.dumps(_routeList, ensure_ascii=False))
-    with open(STOP_LIST, 'w') as f:
+    with open(STOP_LIST, 'w', encoding='UTF-8') as f:
         f.write(json.dumps(stopList, ensure_ascii=False))
         
 if __name__=='__main__':

--- a/crawling/fortuneferry.py
+++ b/crawling/fortuneferry.py
@@ -2,12 +2,12 @@
 
 import json
 
-with open("gtfs.json") as f:
+with open("gtfs.json", 'r', encoding='UTF-8') as f:
   gtfs = json.load(f)
   gtfsRoutes = gtfs["routeList"]
   gtfsStops = gtfs["stopList"]
 
-with open("gtfs-en.json") as f:
+with open("gtfs-en.json", 'r', encoding='UTF-8') as f:
   gtfsEn = json.load(f)
 
 routes = {
@@ -62,8 +62,8 @@ for route in routeList:
       "long": gtfsStops[stopId]["lng"],
     }
 
-with open('routeList.fortuneferry.json', 'w') as f:
+with open('routeList.fortuneferry.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps(routeList, ensure_ascii=False))
 
-with open('stopList.fortuneferry.json', 'w') as f:
+with open('stopList.fortuneferry.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps(stopList, ensure_ascii=False))

--- a/crawling/gmb.py
+++ b/crawling/gmb.py
@@ -6,7 +6,7 @@ import logging
 
 import httpx
 
-from crawling.crawl_utils import emitRequest, get_request_limit
+from crawl_utils import emitRequest, get_request_limit
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ async def getRouteStop(co):
   a_client = httpx.AsyncClient()
   # parse gtfs service_id
   serviceIdMap = {}
-  with open('gtfs/calendar.txt') as csvfile:
+  with open('gtfs/calendar.txt', 'r', encoding="utf-8") as csvfile:
     reader = csv.reader(csvfile)
     headers = next(reader, None)
     for [service_id, mon, tue, wed, thur, fri, sat, sun, *tmp] in reader:
@@ -26,7 +26,7 @@ async def getRouteStop(co):
       if all(i == j for i, j in zip(serviceIdMap_a[service_id], weekdays)):
         return service_id
     return 999
-    raise Exception("No service ID for weekdays: "+json.dumps(weekdays))
+    # raise Exception("No service ID for weekdays: "+json.dumps(weekdays))
 
   def getFreq(headways, serviceIdMap_a):
     freq = {}
@@ -86,13 +86,13 @@ async def getRouteStop(co):
   
   await asyncio.gather(*[get_routes_region(r) for r in ['HKI', 'KLN', "NT"]])
 
-  with open(f'routeList.{co}.json', 'w') as f:
+  with open(f'routeList.{co}.json', 'w', encoding='UTF-8') as f:
     json.dump(routeList, f, ensure_ascii=False)
   logger.info("Route done")
 
 
   req_stops_limit = asyncio.Semaphore(get_request_limit())
-  with open("gtfs.json") as f:
+  with open("gtfs.json", "r", encoding='UTF-8') as f:
     gtfs = json.load(f)
     gtfsStops = gtfs["stopList"]
 
@@ -110,7 +110,7 @@ async def getRouteStop(co):
 
   await asyncio.gather(*[update_stop_loc(stop_id) for stop_id in sorted(stops.keys())])
 
-  with open(f'stopList.{co}.json', 'w') as f:
+  with open(f'stopList.{co}.json', 'w', encoding='UTF-8') as f:
     json.dump(stops,f, ensure_ascii=False)
 
 if __name__=='__main__':

--- a/crawling/hkkf.py
+++ b/crawling/hkkf.py
@@ -33,10 +33,10 @@ for stopId in [1,2,3,4,5,6]:
   apiStops.append(stop)
 
 
-with open("gtfs.json") as f:
+with open("gtfs.json", 'r', encoding="utf-8") as f:
   gtfsZh = json.load(f)
 
-with open("gtfs-en.json") as f:
+with open("gtfs-en.json", 'r', encoding="utf-8") as f:
   gtfs = json.load(f)
   gtfsRoutes = gtfs["routeList"]
   gtfsStops = gtfs["stopList"]
@@ -86,8 +86,8 @@ for apiStop in apiStops:
     "long": apiStop["long"]
   }
 
-with open('routeList.hkkf.json', 'w') as f:
+with open('routeList.hkkf.json', 'w', encoding="utf-8") as f:
   f.write(json.dumps(routeList, ensure_ascii=False))
 
-with open('stopList.hkkf.json', 'w') as f:
+with open('stopList.hkkf.json', 'w', encoding="utf-8") as f:
   f.write(json.dumps(stopList, ensure_ascii=False))

--- a/crawling/kmb.py
+++ b/crawling/kmb.py
@@ -11,7 +11,7 @@ def getRouteStop(co = 'kmb'):
 
     stopList = {}
     if path.isfile(STOP_LIST):
-        with open(STOP_LIST) as f:
+        with open(STOP_LIST, 'r', encoding='UTF-8') as f:
             stopList = json.load(f)
     else:
         # load stops
@@ -59,9 +59,9 @@ def getRouteStop(co = 'kmb'):
         # flatten the routeList back to array
         routeList = [routeList[routeKey] for routeKey in routeList.keys() if not routeKey.startswith('K')]
    
-    with open(ROUTE_LIST, 'w') as f:
+    with open(ROUTE_LIST, 'w', encoding='UTF-8') as f:
         f.write(json.dumps(routeList, ensure_ascii=False))
-    with open(STOP_LIST, 'w') as f:
+    with open(STOP_LIST, 'w', encoding='UTF-8') as f:
         f.write(json.dumps(stopList, ensure_ascii=False))
 
 getRouteStop()

--- a/crawling/lightRail.py
+++ b/crawling/lightRail.py
@@ -56,7 +56,7 @@ for [route, bound, stopCode, stopId, chn, eng, seq] in routes:
       logger.exception(f"Error parsing {url}: {r.text}")
       raise
 
-with open('routeList.lightRail.json', 'w') as f:
+with open('routeList.lightRail.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps([route for route in routeList.values() if len(route['stops']) > 0], ensure_ascii=False))
-with open('stopList.lightRail.json', 'w') as f:
+with open('stopList.lightRail.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps(stopList, ensure_ascii=False))

--- a/crawling/lrtfeeder.py
+++ b/crawling/lrtfeeder.py
@@ -15,7 +15,7 @@ headers = next(reader,None)
 routes = [route for route in reader if len(route) == 4]
 for [route, chn, eng, circular] in routes:
   if route == '':
-    continue;
+    continue
   start = {
     "zh": chn.split('至')[0],
     "en": eng.split(' to ')[0]
@@ -56,7 +56,7 @@ for [route, bound, seq, stationId, lat, lng, name_zh, name_en] in stops:
     "long": lng
   }
 
-with open('routeList.lrtfeeder.json', 'w') as f:
+with open('routeList.lrtfeeder.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps([route for route in routeList.values() if len(route['stops']) > 0], ensure_ascii=False))
-with open('stopList.lrtfeeder.json', 'w') as f:
+with open('stopList.lrtfeeder.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps(stopList, ensure_ascii=False))

--- a/crawling/matchGtfs.py
+++ b/crawling/matchGtfs.py
@@ -5,7 +5,7 @@ from haversine import haversine
 INFINITY_DIST = 1000000
 DIST_DIFF = 600
 
-with open('gtfs.json') as f:
+with open('gtfs.json', 'r', encoding='UTF-8') as f:
   gtfs = json.load(f)
   gtfsRoutes = gtfs['routeList']
   gtfsStops = gtfs['stopList']
@@ -19,7 +19,7 @@ def isNameMatch(name_a, name_b):
 # the actual servicing routes may skip some stop in the coStops
 # this DP function is trying to map the coStops back to GTFS stops
 def matchStopsByDp ( coStops, gtfsStops, co, debug=False ):
-  co = 'unknown' if co not in gtfsStops[0]['stopName'] else co # handle unkown stop
+  co = 'unknown' if co not in gtfsStops[0]['stopName'] else co # handle unknown stop
   if len(gtfsStops) > len(coStops) + 1:
     return [], INFINITY_DIST
   if len(gtfsStops) - len(coStops) == 1:
@@ -117,9 +117,9 @@ def printStopMatches(bestMatch, gtfsStops, stopList, co):
 
 def matchRoutes(co):
   print (co)
-  with open( 'routeList.%s.json' % co ) as f:
+  with open( 'routeList.%s.json' % co, 'r', encoding="utf-8" ) as f:
     routeList = json.load(f)
-  with open( 'stopList.%s.json' % co ) as f:
+  with open( 'stopList.%s.json' % co, 'r', encoding="utf-8" ) as f:
     stopList = json.load(f)
 
   extraRoutes = []
@@ -187,7 +187,7 @@ def matchRoutes(co):
   if co != 'mtr': routeList.extend(extraRoutes)
   routeList = [route for route in routeList if 'found' not in route or 'fares' in route] # skipping routes that just partially mapped to GTFS
     
-  with open( 'routeFareList.%s.json' % co, 'w' ) as f:
+  with open( 'routeFareList.%s.json' % co, 'w', encoding='UTF-8' ) as f:
     f.write(json.dumps(routeList, ensure_ascii=False))
   
 matchRoutes('kmb')
@@ -210,5 +210,5 @@ for routeId, route in gtfsRoutes.items():
 routeFareList = {}
 
 
-with open( 'routeGtfs.all.json', 'w' ) as f:
+with open( 'routeGtfs.all.json', 'w', encoding='UTF-8' ) as f:
   f.write(json.dumps(gtfsRoutes, ensure_ascii=False, indent=4))

--- a/crawling/mergeRoutes.py
+++ b/crawling/mergeRoutes.py
@@ -31,8 +31,8 @@ def isGtfsMatch(knownRoute, newRoute):
   return knownRoute['gtfsId'] in newRoute['gtfs']
   
 def importRouteListJson( co ):
-  _routeList = json.load(open('routeFareList.%s.cleansed.json'%co))
-  _stopList = json.load(open('stopList.%s.json'%co))
+  _routeList = json.load(open('routeFareList.%s.cleansed.json'%co, 'r', encoding='UTF-8'))
+  _stopList = json.load(open('stopList.%s.json'%co, 'r', encoding='UTF-8'))
   for stopId, stop in _stopList.items():
     if stopId not in stopList:
       try:
@@ -163,8 +163,8 @@ routeList = smartUnique()
 for route in routeList:
   route['stops'] = {co: stops for co, stops in route['stops']}
 
-holidays = json.load(open('holiday.json'))
-serviceDayMap = json.load(open('gtfs.json'))['serviceDayMap']
+holidays = json.load(open('holiday.json', 'r', encoding='UTF-8'))
+serviceDayMap = json.load(open('gtfs.json', 'r', encoding='UTF-8'))['serviceDayMap']
 
 def standardizeDict(d):
   return {key: value if not isinstance(value, dict) else standardizeDict(value) for key, value in sorted(d.items())}
@@ -177,8 +177,8 @@ db = standardizeDict({
   'serviceDayMap': serviceDayMap,
 })
 
-with open( 'routeFareList.json', 'w' ) as f:
+with open( 'routeFareList.json', 'w', encoding='UTF-8' ) as f:
   f.write(json.dumps(db, ensure_ascii=False, indent=4))
 
-with open( 'routeFareList.min.json', 'w' ) as f:
+with open( 'routeFareList.min.json', 'w', encoding='UTF-8' ) as f:
   f.write(json.dumps(db, ensure_ascii=False, separators=(',', ':')))

--- a/crawling/mtr.py
+++ b/crawling/mtr.py
@@ -53,7 +53,7 @@ def filterStops(route):
   route['stops'] = [stop for stop in route['stops'] if stop is not None]
   return route
 
-with open('routeList.mtr.json', 'w') as f:
+with open('routeList.mtr.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps(list(map(filterStops, [route for route in routeList.values() if len(route['stops']) > 0])), ensure_ascii=False))
-with open('stopList.mtr.json', 'w') as f:
+with open('stopList.mtr.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps(stopList, ensure_ascii=False))

--- a/crawling/nlb.py
+++ b/crawling/nlb.py
@@ -3,7 +3,7 @@ import json
 import logging
 from os import path
 
-from crawling.crawl_utils import emitRequest
+from crawl_utils import emitRequest
 
 import httpx
 
@@ -40,7 +40,7 @@ async def getRouteStop(co):
 
     stopList = {}
     if path.isfile(STOP_LIST):
-        with open(STOP_LIST) as f:
+        with open(STOP_LIST, 'r', encoding='UTF-8') as f:
             stopList = json.load(f)
    
     async def getRouteStop(routeId):
@@ -79,7 +79,7 @@ async def getRouteStop(co):
 
     await getRouteStopList()
 
-    with open(ROUTE_LIST, 'w') as rf, open(STOP_LIST, 'w') as sf:
+    with open(ROUTE_LIST, 'w', encoding='UTF-8') as rf, open(STOP_LIST, 'w', encoding='UTF-8') as sf:
         json.dump(routeList, rf, ensure_ascii=False)
         json.dump(stopList, sf, ensure_ascii=False)
     logger.info("Dumped lists")

--- a/crawling/parseGtfs.py
+++ b/crawling/parseGtfs.py
@@ -8,15 +8,15 @@ if not path.isfile('gtfs.zip'):
   r = requests.get('https://static.data.gov.hk/td/pt-headway-tc/gtfs.zip')
   open('gtfs.zip', 'wb').write(r.content)
 
-with zipfile.ZipFile("gtfs.zip","r") as zip_ref:
+with zipfile.ZipFile("gtfs.zip", "r") as zip_ref:
   zip_ref.extractall("gtfs")
 
 routeList = {}
 stopList = {}
 serviceDayMap = {}
-routeJourneyTime = json.load(open('routeTime.json'))
+routeJourneyTime = json.load(open('routeTime.json', 'r', encoding='UTF-8'))
 
-with open('gtfs/routes.txt') as csvfile:
+with open('gtfs/routes.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [route_id, agency_id, route_short_name, route_long_name, route_type, route_url] in reader:
@@ -41,7 +41,7 @@ def takeFirst(elem):
   return int(elem[0])
 
 # parse timetable
-with open('gtfs/trips.txt') as csvfile:
+with open('gtfs/trips.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [route_id, service_id, trip_id] in reader:
@@ -53,7 +53,7 @@ with open('gtfs/trips.txt') as csvfile:
     if start_time not in routeList[route_id]['freq'][bound][calendar]:
       routeList[route_id]['freq'][bound][calendar][start_time] = None
 
-with open('gtfs/frequencies.txt') as csvfile:
+with open('gtfs/frequencies.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [trip_id, _start_time, end_time, headway_secs] in reader:
@@ -61,7 +61,7 @@ with open('gtfs/frequencies.txt') as csvfile:
     routeList[route_id]['freq'][bound][calendar][start_time] = (end_time[0:5].replace(':', ''), headway_secs)
 
 # parse stop seq
-with open('gtfs/stop_times.txt') as csvfile:
+with open('gtfs/stop_times.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [trip_id, arrival_time, departure_time, stop_id, stop_sequence, pickup_type, drop_off_type, timepoint] in reader:
@@ -71,7 +71,7 @@ with open('gtfs/stop_times.txt') as csvfile:
     routeList[route_id]['stops'][bound][stop_sequence] = stop_id
 
 # parse fares
-with open('gtfs/fare_attributes.txt') as csvfile:
+with open('gtfs/fare_attributes.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [fare_id,price,currency_type,payment_method,transfers,agency_id] in reader:
@@ -105,7 +105,7 @@ def parseStopName(name):
   return ret
   
 
-with open('gtfs/stops.txt') as csvfile:
+with open('gtfs/stops.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [stop_id,stop_name,stop_lat,stop_lon,zone_id,location_type,stop_timezone] in reader:
@@ -116,7 +116,7 @@ with open('gtfs/stops.txt') as csvfile:
       'lng': float(stop_lon) 
     }
 
-with open('gtfs/calendar.txt') as csvfile:
+with open('gtfs/calendar.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for line in reader:
@@ -124,7 +124,7 @@ with open('gtfs/calendar.txt') as csvfile:
     serviceDayMap[service_id] = [sun, mon, tue, wed, thur, fri, sat]
 
 import json
-with open('gtfs.json', 'w') as f:
+with open('gtfs.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps({
     'routeList': routeList,
     'stopList': stopList,

--- a/crawling/parseGtfsEn.py
+++ b/crawling/parseGtfsEn.py
@@ -8,15 +8,15 @@ if not path.isfile('gtfs-en.zip'):
   r = requests.get('https://static.data.gov.hk/td/pt-headway-en/gtfs.zip')
   open('gtfs-en.zip', 'wb').write(r.content)
 
-with zipfile.ZipFile("gtfs-en.zip","r") as zip_ref:
+with zipfile.ZipFile("gtfs-en.zip", "r") as zip_ref:
   zip_ref.extractall("gtfs-en")
 
 routeList = {}
 stopList = {}
 serviceDayMap = {}
-routeJourneyTime = json.load(open('routeTime.json'))
+routeJourneyTime = json.load(open('routeTime.json', 'r', encoding='UTF-8'))
 
-with open('gtfs-en/routes.txt') as csvfile:
+with open('gtfs-en/routes.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [route_id, agency_id, route_short_name, route_long_name, route_type, route_url] in reader:
@@ -41,7 +41,7 @@ def takeFirst(elem):
   return int(elem[0])
 
 # parse timetable
-with open('gtfs-en/trips.txt') as csvfile:
+with open('gtfs-en/trips.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [route_id, service_id, trip_id] in reader:
@@ -53,7 +53,7 @@ with open('gtfs-en/trips.txt') as csvfile:
     if start_time not in routeList[route_id]['freq'][bound][calendar]:
       routeList[route_id]['freq'][bound][calendar][start_time] = None
 
-with open('gtfs-en/frequencies.txt') as csvfile:
+with open('gtfs-en/frequencies.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [trip_id, _start_time, end_time, headway_secs] in reader:
@@ -61,7 +61,7 @@ with open('gtfs-en/frequencies.txt') as csvfile:
     routeList[route_id]['freq'][bound][calendar][start_time] = (end_time[0:5].replace(':', ''), headway_secs)
 
 # parse stop seq
-with open('gtfs-en/stop_times.txt') as csvfile:
+with open('gtfs-en/stop_times.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [trip_id, arrival_time, departure_time, stop_id, stop_sequence, pickup_type, drop_off_type, timepoint] in reader:
@@ -71,7 +71,7 @@ with open('gtfs-en/stop_times.txt') as csvfile:
     routeList[route_id]['stops'][bound][stop_sequence] = stop_id
 
 # parse fares
-with open('gtfs-en/fare_attributes.txt') as csvfile:
+with open('gtfs-en/fare_attributes.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [fare_id,price,currency_type,payment_method,transfers,agency_id] in reader:
@@ -105,7 +105,7 @@ def parseStopName(name):
   return ret
   
 
-with open('gtfs-en/stops.txt') as csvfile:
+with open('gtfs-en/stops.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for [stop_id,stop_name,stop_lat,stop_lon,zone_id,location_type,stop_timezone] in reader:
@@ -116,7 +116,7 @@ with open('gtfs-en/stops.txt') as csvfile:
       'lng': float(stop_lon) 
     }
 
-with open('gtfs-en/calendar.txt') as csvfile:
+with open('gtfs-en/calendar.txt', 'r', encoding='UTF-8') as csvfile:
   reader = csv.reader(csvfile)
   headers = next(reader, None)
   for line in reader:
@@ -124,7 +124,7 @@ with open('gtfs-en/calendar.txt') as csvfile:
     serviceDayMap[service_id] = [sun, mon, tue, wed, thur, fri, sat]
 
 import json
-with open('gtfs-en.json', 'w') as f:
+with open('gtfs-en.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps({
     'routeList': routeList,
     'stopList': stopList,

--- a/crawling/parseJourneyTime.py
+++ b/crawling/parseJourneyTime.py
@@ -5,7 +5,7 @@ from os import path
 if not path.isfile('ROUTE_BUS.xml'):
   r = requests.get('https://static.data.gov.hk/td/routes-fares-xml/ROUTE_BUS.xml')
   r.encoding = 'utf-8'
-  with open('ROUTE_BUS.xml', 'w') as f:
+  with open('ROUTE_BUS.xml', 'w', encoding='UTF-8') as f:
     f.write(r.text)
 
 routeTimeList = {}
@@ -20,5 +20,5 @@ for route in root.iter('ROUTE'):
     }
 
 import json
-with open('routeTime.json', 'w') as f:
+with open('routeTime.json', 'w', encoding='UTF-8') as f:
   f.write(json.dumps(routeTimeList, ensure_ascii=False))

--- a/crawling/requirements.txt
+++ b/crawling/requirements.txt
@@ -1,14 +1,14 @@
 brotlipy==0.7.0
 certifi==2020.12.5
-cffi==1.14.5
+cffi==1.15.0
 chardet==4.0.0
 cryptography==3.4.7
 haversine==2.3.0
 idna==2.10
 pycparser==2.20
 pyOpenSSL==20.0.1
-PySocks==1.7.1
 requests==2.25.1
+PySocks==1.7.1
 six==1.15.0
 urllib3==1.26.4
 wheel==0.36.2

--- a/crawling/sunferry.py
+++ b/crawling/sunferry.py
@@ -2,10 +2,10 @@
 
 import json
 
-with open("gtfs.json") as f:
+with open("gtfs.json", 'r', encoding="utf-8") as f:
   gtfsZh = json.load(f)
 
-with open("gtfs-en.json") as f:
+with open("gtfs-en.json", 'r', encoding="utf-8") as f:
   gtfs = json.load(f)
   gtfsRoutes = gtfs["routeList"]
   gtfsStops = gtfs["stopList"]
@@ -73,9 +73,9 @@ for route in routeList:
       "long": gtfsStops[stopId]["lng"],
     }
 
-with open('routeList.sunferry.json', 'w') as f:
+with open('routeList.sunferry.json', 'w', encoding='UTF-8' ) as f:
   f.write(json.dumps(routeList, ensure_ascii=False))
 
 
-with open('stopList.sunferry.json', 'w') as f:
+with open('stopList.sunferry.json', 'w', encoding='UTF-8' ) as f:
   f.write(json.dumps(stopList, ensure_ascii=False))

--- a/run_crawling.bat
+++ b/run_crawling.bat
@@ -1,0 +1,20 @@
+@echo off
+
+python ./crawling/parseHoliday.py pause
+python ./crawling/ctb.py pause
+python ./crawling/kmb.py pause
+python ./crawling/nlb.py pause
+python ./crawling/lrtfeeder.py pause
+python ./crawling/lightRail.py pause
+python ./crawling/mtr.py pause
+python ./crawling/parseJourneyTime.py pause
+python ./crawling/parseGtfs.py pause
+python ./crawling/parseGtfsEn.py pause
+python ./crawling/sunferry.py pause
+python ./crawling/fortuneferry.py pause
+python ./crawling/hkkf.py pause
+python ./crawling/gmb.py pause
+python ./crawling/matchGtfs.py pause
+python ./crawling/cleansing.py pause
+python ./crawling/mergeRoutes.py pause
+


### PR DESCRIPTION
Add support to Windows & Python 3.10 Environment.
1. Improved readme typos & installation information
2. Fixed the decoding issue on Windows Host (on Linux/MacOS is default by UTF8, but Windows).
3. Updated packages to support Python 3.10
4. Added .bat script "run_crawling.bat" for run all the python scripts on Windows.


*Addidtion info on item 2:
Fixed error on decoding when calling `with open()`: 
```
File "d:\GitLab\hk-bus-crawling\hkbus\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
UnicodeDecodeError: 'cp950' codec can't decode byte 0x9c in position 98: illegal multibyte sequence
``` 
Reference of  `open()` on Windows platofrm:  [Python 3 Offical Doc](https://docs.python.org/3/glossary.html#term-locale-encoding)