### PR TITLE
Try to strategically and deterministically pick gmb stop names

### DIFF
--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -59,6 +59,7 @@ jobs:
             holiday.json
             routeFareList*
             routeList*
+            stopCandidates*
             stopList*
             stopMap*
             routeTime.json

--- a/crawling/gmb.py
+++ b/crawling/gmb.py
@@ -43,18 +43,80 @@ async def getRouteStop(co):
   routeList = []
   stops = {}
 
+  stopCandidates = {}
+
   async def get_route_directions(route, route_no):
     service_type = 2
     for direction in route['directions']:
       rs = await emitRequest('https://data.etagmb.gov.hk/route-stop/'+str(route['route_id'])+'/'+str(direction['route_seq']), a_client)
       for stop in rs.json()['data']['route_stops']:
         stop_id = stop['stop_id']
-        if stop_id not in stops:
-          stops[str(stop_id)] = {
-            "stop": str(stop_id), 
-            "name_en": stop['name_en'], 
-            "name_tc": stop['name_tc'], 
-          }
+
+        # GMB ETA API Spec: "A stop may have different names under different routes"
+        # While hk-bus-crawling only allows one name per stop
+        # Try to strategically and deterministically pick a stop name
+        oldNameEn = stops[str(stop_id)]['name_en'] if str(
+            stop_id) in stops else ""
+        oldNameTc = stops[str(stop_id)]['name_tc'] if str(
+            stop_id) in stops else ""
+        newNameEn = stop['name_en'].strip()
+        newNameTc = stop['name_tc'].strip()
+        useNameEn = oldNameEn
+        useNameTc = oldNameTc
+        toReplace = False
+
+        # Prefer longer Chinese names. They are usually more specific
+        # e.g. "常安街, 柴灣消防局對面" over "常安街77號"
+        # e.g. "小西灣道, 香港學術及職業資歷評審局外" over "小西灣道, 近曉翠街"
+        # e.g. "暢運道, 近國際都會都會大廈" over "暢運道, 近紅磡站", "紅磡站, 暢運道"
+        # Note: "柴灣道, 筲箕灣官立中學外" over "柴灣道, 筲箕灣官立中學"
+        # Note: "大坑東道, 大坑東遊樂場外" over "大坑東道,大坑東遊樂場外"
+        # Note: "亞皆老街113號, 太平道" over "亞皆老街, 嘉麗園", "亞皆老街, 近嘉麗園", "亞皆老街113號"
+        # Note: "貿業路, 寶琳港鐵站外" "Po Lam Station" over "貿業路, 近寶琳站" "Mau Yip Road,
+        # near Po Lam Station"
+        if len(newNameTc) > len(oldNameTc):
+          toReplace = True
+        elif len(newNameTc) == len(oldNameTc):
+          if newNameTc > oldNameTc:
+            toReplace = True
+          elif newNameTc == oldNameTc:
+            # Prefer English names with more words
+            if len(newNameEn.split()) > len(oldNameEn.split()):
+              toReplace = True
+            elif len(newNameEn.split()) == len(oldNameEn.split()):
+              if len(newNameEn) > len(oldNameEn):
+                toReplace = True
+              elif len(newNameEn) == len(oldNameEn):
+                if newNameEn > oldNameEn:
+                  toReplace = True
+        if toReplace:
+          useNameTc = newNameTc
+          useNameEn = newNameEn
+
+        if oldNameEn.upper() == newNameEn.upper():
+          # Prefer fewer uppercase letters
+          # e.g. "Pok Fu Lam Road" over "POK FU LAM ROAD"
+          # e.g. "Tsing Yi Heung Sze Wui Road, Near Greenfield Garden Block 3"
+          # over "TSING YI HEUNG SZE WUI ROAD, near Greenfield Garden Block 3"
+          useNameEn = newNameEn if sum(
+              1 for c in newNameEn if c.isupper()) < sum(
+              1 for c in oldNameEn if c.isupper()) else oldNameEn
+
+        if str(stop_id) not in stopCandidates:
+          stopCandidates[str(stop_id)] = {'en_used': '',
+                                          'en_others': set(),
+                                          'tc_used': '',
+                                          'tc_others': set()}
+        stopCandidates[str(stop_id)]['en_used'] = useNameEn
+        stopCandidates[str(stop_id)]['en_others'].add(newNameEn)
+        stopCandidates[str(stop_id)]['tc_used'] = useNameTc
+        stopCandidates[str(stop_id)]['tc_others'].add(newNameTc)
+
+        stops[str(stop_id)] = {
+            "stop": str(stop_id),
+            "name_en": useNameEn,
+            "name_tc": useNameTc,
+        }
       routeList.append({
         "gtfsId": str(route['route_id']),
         "route": route_no,
@@ -112,6 +174,19 @@ async def getRouteStop(co):
 
   with open(f'stopList.{co}.json', 'w', encoding='UTF-8') as f:
     json.dump(stops,f, ensure_ascii=False)
+  for stop in stopCandidates:
+    stopCandidates[stop]["tc_others"].discard(stopCandidates[stop]["tc_used"])
+    stopCandidates[stop]["tc_others"] = sorted(
+        stopCandidates[stop]["tc_others"])
+    stopCandidates[stop]["en_others"].discard(stopCandidates[stop]["en_used"])
+    stopCandidates[stop]["en_others"] = sorted(
+        stopCandidates[stop]["en_others"])
+  with open(f'stopCandidates.{co}.json', 'w', encoding='UTF-8') as f:
+    def set_default(obj):
+      if isinstance(obj, set):
+          return list(obj)
+      raise TypeError
+    json.dump(stopCandidates, f, ensure_ascii=False, default=set_default)
 
 if __name__=='__main__':
     logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
According to the GMB ETA API specification, "A stop may have different names under different routes", while `hk-bus-crawling` only allows one name per stop.

There are around 800 out of 4000 stops with either multiple TC names or multiple EN names.

Example:

- Stop ID: 20003454
  - 小西灣道, 近曉翠街 Siu Sai Wan Road, near Hiu Tsui Street
  - 小西灣道, 香港學術及職業資歷評審局外 Siu Sai Wan Road, outside the Hong Kong Council for Accreditation of Academic and Vocational Qualifications
  - 小西灣道, 香港學術及職業資歷評審局外 Siu Sai Wan Road, HKCAAVQ
- Stop ID: 20000475
  - 暢運道, 近紅磡站 Cheong Wan Road, near Hung Hom Station
  - 暢運道, 近國際都會都會大廈 Cheong Wan Road, near The Metropolis Tower
  - 紅磡站, 暢運道 Hung Hom Station, Cheong Wan Road

The current implementation picks the GMB stop name non-deterministically based on the order in which the async network requests are being completed. GMB stops of `routeFareList.json` generated by two crawling scripts running at the same time may vary to a certain extent even though nothing is actually changed at the source.

For `routeFareList.json`,
|                                                                                                                                                                                       | Before (number of different lines) | After (number of differnet lines) | Diff (number of different lines) |
|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|-----------------------------------|----------------------------------|
| Between Jan 3 & Jan 4 https://github.com/hkbus/hk-bus-crawling/commit/262bf23dce9be9c6172c9162b7b1210f2d8513cd#diff-ef21849efec401e2901c3e1c238c4cf53a13c529791a4417c6a04499ec999dea  | +453 -430                          | +237 -214                         | 216 fewer                        |
| Between Jan 2 & Jan 3 https://github.com/hkbus/hk-bus-crawling/commit/9ed746b3549a4b8e22d1128ec1dc5526916f414b#diff-ef21849efec401e2901c3e1c238c4cf53a13c529791a4417c6a04499ec999dea  | +230 -230                          | 0                                 | 230 fewer                        |
| Between Jan 1 & Jan 2 https://github.com/hkbus/hk-bus-crawling/commit/0dc28435d58bef7d1641a0dd7b2669be985ad3ad#diff-ef21849efec401e2901c3e1c238c4cf53a13c529791a4417c6a04499ec999dea  | +1969 -1123                        | +1746 -900                        | 223 fewer                        |
| Between Dec 31 & Jan 1 https://github.com/hkbus/hk-bus-crawling/commit/848a9b27ed9327f4feeb5b6180fc5aed60d806e8#diff-ef21849efec401e2901c3e1c238c4cf53a13c529791a4417c6a04499ec999dea | +1037 -372                         | +811 -146                         | 226 fewer                        |

After this PR, on Jan 3, no commit is created by Github Action as the outputs are totally identical (including but not limited to `routeFareList.min.json` and `routeFareList.md5`).

This PR aims to strategically and deterministically pick GMB stop names. Note the "algorithm" to pick the names are very naive at the moment.
