### PR TITLE
amend gmb service type caused by decription_tc with spaces around 正常班次 at source

### DIFF
--- a/crawling/gmb.py
+++ b/crawling/gmb.py
@@ -133,12 +133,12 @@ async def getRouteStop(co):
           "dest_tc": direction['dest_tc'],
           "dest_en": direction['dest_en'],
           "bound": 'O' if direction['route_seq'] == 1 else 'I',
-          "service_type": 1 if route["description_tc"] == '正常班次' else service_type,
+          "service_type": 1 if route["description_tc"].strip() == '正常班次' else service_type,
           "stops": [str(stop['stop_id']) for stop in rs.json()['data']['route_stops']],
           "freq": getFreq(direction['headways'], serviceIdMap)
       })
       # print(routeList)
-      if route["description_tc"] != '正常班次':
+      if route["description_tc"].strip() != '正常班次':
         service_type += 1
 
   req_route_limit = asyncio.Semaphore(get_request_limit())


### PR DESCRIPTION
around 25 routes and 45 route-service_type-bounds are affected

Example:
```json
{
    "type": "Route",
    "version": "1.0",
    "generated_timestamp": "2025-01-01T00:00:00.000+08:00",
    "data": [
        {
            "route_id": 2002317,
            "region": "HKI",
            "route_code": "18M",
            "description_tc": "正常班次 ", // Note the extra space after 正常班次
            "description_sc": "正常班次 ",
            "description_en": "Normal Route",
            "directions": [
                {...},
                {...}
            ],
            "data_timestamp": "2024-04-04T17:54:14.825+08:00"
        }
    ]
}
```

routeList.gmb.json
```json
{
    "gtfsId": "2002317",
    "route": "18M",
    "orig_tc": "柴灣站",
    "orig_en": "Chai Wan Station",
    "dest_tc": "歌連臣角(懲教所)",
    "dest_en": "Cape Collinson (Correctional Institution)",
    "bound": "O",
    "service_type": 2, // Before: 2; After: 1
    "stops": [
      "20000103",
      "20003431",
      "20009700",
      "20003432",
      "20003433",
      "20000104"
    ],
    "freq": {
      "127": { "0800": null, "1230": null, "1645": null },
      "111": { "1000": null, "1500": null }
    }
  },
  {
    "gtfsId": "2002317",
    "route": "18M",
    "orig_tc": "歌連臣角(懲教所)",
    "orig_en": "Cape Collinson (Correctional Institution)",
    "dest_tc": "柴灣站",
    "dest_en": "Chai Wan Station",
    "bound": "I",
    "service_type": 3, // Before: 3; After: 1
    "stops": ["20000104", "20003434", "20003435", "20003436", "20000103"],
    "freq": {
      "127": { "0815": null, "1245": null, "1700": null },
      "111": { "1015": null, "1515": null }
    }
  },
```