### PR TITLE
Improve Light Rail Data Crawling & Stop Accuracy

### DIFF
--- a/crawling/lightRail.py
+++ b/crawling/lightRail.py
@@ -60,8 +60,8 @@ async def getRouteStop(co='lightRail'):
       lightRailObject["orig_tc"] = chn
       lightRailObject["orig_en"] = eng
       routeCollection.add(key)
-    lightRailObject["dest_tc"] = chn
-    lightRailObject["dest_en"] = eng
+    lightRailObject["dest_tc"] = chn + " (循環線)" if route in circularRoutes else chn
+    lightRailObject["dest_en"] = eng + " (Circular)" if route in circularRoutes else eng
     if not lightRailObject["stops"] or lightRailObject["stops"][-1] != lightRailId:
       if route in circularRoutes and seq != "1.00":
         # Avoid adding the same stop (orig & dest) twice in circular routes

--- a/crawling/lightRail.py
+++ b/crawling/lightRail.py
@@ -44,7 +44,7 @@ async def getRouteStop(co='lightRail'):
     routeList[route + "_" + bound]["dest_en"] = eng
     routeList[route + "_" + bound]["stops"].append("LR" + stopId)
     if "LR" + stopId not in stopList:
-      url = 'https://geodata.gov.hk/gs/api/v1.0.0/locationSearch?q=輕鐵－' + chn
+      url = f'https://geodata.gov.hk/gs/api/v1.0.0/locationSearch?q={chn}輕鐵站'
       r = await emitRequest(url, a_client, headers={'Accept': 'application/json'})
       try:
         lat, lng = epsgTransformer.transform(


### PR DESCRIPTION
This PR updates light rail data crawling and includes bug fixes for stop positions, circular routes, and duplicate stops.

## Update for light rail stops position

Coordinates for some stops were incorrect due to a mismatch in the locationSearch API. Here are the affected stops:

- LR020 (輕鐵車廠 / Light Rail Depot) 
- LR100 (兆康 / Siu Hong)
- LR220 (大興(南) / Tai Hing (South))
- LR280 (市中心 / Town Centre)
- LR295 (屯門 / Tuen Mun)
- LR380 (洪水橋 / Hung Shui Kiu)
- LR430 (天水圍 / Tin Shui Wai)
- LR500 (天榮 / Tin Wing)
- LR600 (元朗 / Yuen Long)

The parameter update ensures the first result matches the intended stop.

``` diff
- locationSearch?q=輕鐵－' + chn
+ locationSearch?q={chn}輕鐵站'
```

## Update for light rail routes

Some routes contained duplicate stops, and circular routes were incorrectly split into two bounds. Here are the affected routes:
``` diff
+ 507_I (duplicate stop removed)
- 705_I (route removed)
+ 705_O (stops combined)
- 706_I (route removed)
+ 706_O (stops combined)
+ 751_O (duplicate stop removed)
+ 761P_I (duplicate stop removed)
```
