### PR TITLE
migrate Github workflows away from deprecated Node.js 20 actions

### DIFF
--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -18,7 +18,7 @@ jobs:
       ALPHA_BRANCH_NAME: alpha
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Setup Python environment
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
             python-version: '3.12'
             architecture: 'x64'
@@ -91,7 +91,7 @@ jobs:
           md5sum routeFareList.alpha.min.json | cut -f1 -d ' ' | tr -d $'\n' > routeFareList.alpha.md5
 
       - name: Archive crawling outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: Crawled Files

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -6,7 +6,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Format code
         id: autopep8
         uses: peter-evans/autopep8@v2


### PR DESCRIPTION
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: .... Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

https://github.com/hkbus/hk-bus-crawling/actions/runs/25551421923