### PR TITLE
Update eta.py (def lightrail) to handle additionalInfo1, routeRemarkE…

### DIFF
--- a/hk_bus_eta/eta.py
+++ b/hk_bus_eta/eta.py
@@ -199,31 +199,51 @@ class HKEta:
       })
     return ret
 
-  def lightrail(self, stop_id, route, dest):
+def lightrail(self, stop_id, route, dest):
     platform_list = requests.get(
-        "https://rt.data.gov.hk/v1/transport/mtr/lrt/getSchedule?station_id={}&with_special=1".format(stop_id[2:])).json()["platform_list"]
+        "https://rt.data.gov.hk/v1/transport/mtr/lrt/getSchedule?station_id={}&with_special=1".format(stop_id[2:])).json().get("platform_list", [])
     ret = []
     for platform in platform_list:
-      route_list, platform_id = platform["route_list"], platform["platform_id"]
-      for e in route_list:
-        route_no, dest_ch, dest_en, stop, time_en = e["route_no"], e[
-            "dest_ch"], e["dest_en"], e["stop"], e["time_en"]
-        if route == route_no and (
-                dest_ch == dest["zh"] or "Circular" in dest_en) and stop == 0:
-          waitTime = 0
-          if time_en.lower() == "arriving" or time_en.lower() == "departing" or time_en == "-":
-            waitTime = 0
-          else:
-            waitTime = int(re.search(r'\d+', time_en).group())
-          dt = datetime.fromtimestamp(time.time() + waitTime + 8 * 3600)
-          ret.append({
-              "eta": dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+08:00"),
-              "remark": {
-                  "zh": get_platform_display(platform_id, "zh"),
-                  "en": get_platform_display(platform_id, "en")
-              },
-              "co": "lightrail"
-          })
+        route_list = platform.get("route_list") or []
+        platform_id = platform.get("platform_id")
+        for e in route_list:
+            route_no = e.get("route_no")
+            additionalInfo1 = e.get("additionalInfo1")
+            dest_ch = e.get("dest_ch")
+            dest_en = e.get("dest_en") or []
+            stop = e.get("stop")
+            time_en = (e.get("time_en") or "").strip()
+            # match route number OR additionalInfo1
+            if (route == route_no or route == additionalInfo1) and (dest_ch == dest.get("zh") or any("Circular" in s for s in dest_en)) and stop == 0:
+                # parse wait time defensively
+                waitTime = 0
+                te = time_en.lower()
+                if te in ("arriving", "departing", "-") or te == "":
+                    waitTime = 0
+                else:
+                    m = re.search(r'\d+', time_en)
+                    waitTime = int(m.group()) if m else 0
+                dt = datetime.fromtimestamp(time.time() + waitTime * 60 + 8 * 3600)
+                # platform text
+                plat_zh = get_platform_display(platform_id, "zh")
+                plat_en = get_platform_display(platform_id, "en")
+                # append routeRemarkChi2 / routeRemarkEng2 if present
+                remark_chi2 = e.get("routeRemarkChi2") or e.get("routeRemarkChi2", "")  # defensive access
+                remark_eng2 = e.get("routeRemarkEng2") or e.get("routeRemarkEng2", "")
+                remark_zh = plat_zh
+                if remark_chi2:
+                    remark_zh = "{} - {}".format(plat_zh, remark_chi2)
+                remark_en = plat_en
+                if remark_eng2:
+                    remark_en = "{} - {}".format(plat_en, remark_eng2)
+                ret.append({
+                    "eta": dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+08:00"),
+                    "remark": {
+                        "zh": remark_zh,
+                        "en": remark_en
+                    },
+                    "co": "lightrail"
+                })
     return ret
 
   def gmb(self, gtfs_id, stop_id, bound, seq):


### PR DESCRIPTION
…ng2, routeRemarkChi2

…RemarkChi2

This is a part of [Update lightRail.py with separated csv urls](https://github.com/hkbus/hk-bus-crawling/pull/44) phase 1.5.

I have mentioned that we need to recognize special routes' number via the value of additionalInfo1.

by GPT-5 mini:

Updated lightrail implementation below—it:
- matches additionalInfo1 the same way as route_no,
- appends routeRemarkEng2 to remark.en,
- appends routeRemarkChi2 to remark.zh,
- handles missing fields defensively.