### PR TITLE
Relabel NLB route bound by matched GTFS direction

### DIFF
--- a/crawling/matchGtfs.py
+++ b/crawling/matchGtfs.py
@@ -167,6 +167,9 @@ def matchRoutes(co):
           ret, bound, stops, route = bestMatch[2:]
 
           routeCandidate = route.copy()
+          # NLB hardcodes bound "O"; set from GTFS dir (1->O, 2->I).
+          if co == 'nlb':
+            routeCandidate['bound'] = 'O' if bound == '1' else 'I'
           if (
               len(ret) == len(
                   route['stops']) or len(ret) +


### PR DESCRIPTION
**TL;DR:** Every NLB route is stamped `bound = "O"`, so both directions resolve to the same `{gtfsId}-O.json` map-waypoint file and the app draws the identical polyline both ways. Relabel NLB's bound by the matched GTFS direction (**2 lines**, NLB-scoped). **Verified through the full pipeline** (below): before, all NLB routes were `O`; after, the reverse directions correctly become `I`.

Fixes hkbus/hk-independent-bus-eta#149.

<details><summary><b>Verification — ran the pipeline on live data (before vs after)</b></summary>

`nlb.py` → `parseJourneyTime.py` → `parseGtfs.py` → `matchRoutes('nlb')`, then inspected `routeFareList.nlb.json`:

| | route 1 `Mui Wo→Tai O` | route 1 `Tai O→Mui Wo` | all NLB bounds |
|---|---|---|---|
| **Before (master)** | `O` | `O` — same `1723-O.json` (the bug) | `{"O": 156}` |
| **After (this PR)** | `O` | `I` — its own `1723-I.json` | `{"O": 124, "I": 32}` |

So 32 NLB directions that previously shared a waypoint file now resolve to their own. The `-I.json` files already exist on the waypoint host, so no app change is needed.
</details>

<details><summary><b>Root cause + why it's deterministic</b></summary>

- `crawling/nlb.py` hardcodes `"bound": "O"` — the NLB gov API returns each direction as a separate route with no I/O flag.
- Waypoint files split by `route_seq` (1 → `-O.json`, 2 → `-I.json`), keyed by the same `route_id` as GTFS.
- `matchRoutes()` already resolves each NLB direction to its GTFS bound (`1`/`2`); the var is in scope where the route record is built, it just never got copied in. GTFS bound `1`↔`O`, `2`↔`I` — the convention KMB/CTB already rely on.
- Fix: `if co == 'nlb': routeCandidate['bound'] = 'O' if bound == '1' else 'I'`. Fares/freq index by the GTFS bound, not this field, so they're unaffected.
</details>

<details><summary><b>Review + honest residual risk</b></summary>

- `autopep8 --aggressive --aggressive --indent-size=2` clean; `py_compile` OK. Codex (independent review): no blockers — confirmed NLB-gating (KMB/CTB untouched) and that downstream `mergeRoutes.py` expects the `O`/`I` shape.
- Any GTFS bound other than `1` maps to `I` (silent). NLB data uses `1`/`2`; a stricter `elif bound == '2'` would fail loud on unexpected upstream data — happy to add if you prefer.
</details>
