### PR TITLE
Surface MTR Bus busStopRemark (pip twin of hk-bus-eta fix) + repair module IndentationError on master

### DIFF
--- a/hk_bus_eta/eta.py
+++ b/hk_bus_eta/eta.py
@@ -200,55 +200,55 @@ class HKEta:
     return ret
 
 
-def lightrail(self, stop_id, route, dest):
+  def lightrail(self, stop_id, route, dest):
     platform_list = requests.get(
         "https://rt.data.gov.hk/v1/transport/mtr/lrt/getSchedule?station_id={}&with_special=1".format(stop_id[2:])).json().get("platform_list", [])
     ret = []
     for platform in platform_list:
-        route_list = platform.get("route_list") or []
-        platform_id = platform.get("platform_id")
-        for e in route_list:
-            route_no = e.get("route_no")
-            additionalInfo1 = e.get("additionalInfo1")
-            dest_ch = e.get("dest_ch")
-            dest_en = e.get("dest_en") or []
-            stop = e.get("stop")
-            time_en = (e.get("time_en") or "").strip()
-            # match route number OR additionalInfo1
-            if (route == route_no or route == additionalInfo1) and (dest_ch == dest.get(
+      route_list = platform.get("route_list") or []
+      platform_id = platform.get("platform_id")
+      for e in route_list:
+        route_no = e.get("route_no")
+        additionalInfo1 = e.get("additionalInfo1")
+        dest_ch = e.get("dest_ch")
+        dest_en = e.get("dest_en") or []
+        stop = e.get("stop")
+        time_en = (e.get("time_en") or "").strip()
+        # match route number OR additionalInfo1
+        if (route == route_no or route == additionalInfo1) and (dest_ch == dest.get(
                 "zh") or any("Circular" in s for s in dest_en)) and stop == 0:
-                # parse wait time defensively
-                waitTime = 0
-                te = time_en.lower()
-                if te in ("arriving", "departing", "-") or te == "":
-                    waitTime = 0
-                else:
-                    m = re.search(r'\d+', time_en)
-                    waitTime = int(m.group()) if m else 0
-                dt = datetime.fromtimestamp(
-    time.time() + waitTime * 60 + 8 * 3600)
-                # platform text
-                plat_zh = get_platform_display(platform_id, "zh")
-                plat_en = get_platform_display(platform_id, "en")
-                # append routeRemarkChi2 / routeRemarkEng2 if present
-                remark_chi2 = e.get("routeRemarkChi2") or e.get(
-                    "routeRemarkChi2", "")  # defensive access
-                remark_eng2 = e.get("routeRemarkEng2") or e.get(
-                    "routeRemarkEng2", "")
-                remark_zh = plat_zh
-                if remark_chi2:
-                    remark_zh = "{} - {}".format(plat_zh, remark_chi2)
-                remark_en = plat_en
-                if remark_eng2:
-                    remark_en = "{} - {}".format(plat_en, remark_eng2)
-                ret.append({
-                    "eta": dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+08:00"),
-                    "remark": {
-                        "zh": remark_zh,
-                        "en": remark_en
-                    },
-                    "co": "lightrail"
-                })
+          # parse wait time defensively
+          waitTime = 0
+          te = time_en.lower()
+          if te in ("arriving", "departing", "-") or te == "":
+            waitTime = 0
+          else:
+            m = re.search(r'\d+', time_en)
+            waitTime = int(m.group()) if m else 0
+          dt = datetime.fromtimestamp(
+              time.time() + waitTime * 60 + 8 * 3600)
+          # platform text
+          plat_zh = get_platform_display(platform_id, "zh")
+          plat_en = get_platform_display(platform_id, "en")
+          # append routeRemarkChi2 / routeRemarkEng2 if present
+          remark_chi2 = e.get("routeRemarkChi2") or e.get(
+              "routeRemarkChi2", "")  # defensive access
+          remark_eng2 = e.get("routeRemarkEng2") or e.get(
+              "routeRemarkEng2", "")
+          remark_zh = plat_zh
+          if remark_chi2:
+            remark_zh = "{} - {}".format(plat_zh, remark_chi2)
+          remark_en = plat_en
+          if remark_eng2:
+            remark_en = "{} - {}".format(plat_en, remark_eng2)
+          ret.append({
+              "eta": dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+08:00"),
+              "remark": {
+                  "zh": remark_zh,
+                  "en": remark_en
+              },
+              "co": "lightrail"
+          })
     return ret
 
   def gmb(self, gtfs_id, stop_id, bound, seq):

--- a/hk_bus_eta/eta.py
+++ b/hk_bus_eta/eta.py
@@ -159,9 +159,12 @@ class HKEta:
     data = list(filter(lambda e: e["busStopId"] == stop_id, data))
     ret = []
     for buses in data:
+      bus_stop_remark = buses.get("busStopRemark")
       for bus in buses['bus']:
         remark = ""
-        if bus["busRemark"] is not None:
+        if bus_stop_remark:
+          remark = bus_stop_remark
+        elif bus["busRemark"] is not None:
           remark = bus["busRemark"]
         elif bus["isScheduled"] == 1:
           remark = "Scheduled" if language == "en" else "預定班次"


### PR DESCRIPTION
## TL;DR

Python twin of the fix just filed on the npm package (https://github.com/hkbus/hk-bus-eta/pull/27), as suggested in the group (「你可以改埋呢個」pointing at `hk_bus_eta/eta.py` L151): `lrtfeeder` never reads the per-stop `busStopRemark`, so the pip package returns plain ETAs for stops MTR itself flags as suspended/relocated (the K18 report). Fix mirrors the npm one: fold `busStopRemark` into `remark` with top priority — 3 lines.

**Heads-up, second commit here is a blocker-repair:** `hk_bus_eta/eta.py` on current master **does not parse** — `def lightrail` was recently committed at module level with 4-space indentation in this 2-space file, so `import hk_bus_eta` raises `IndentationError` (at `def gmb`), `HKEta` has no `lightrail` method, and any PyPI release cut from master would ship broken. (The auto-format bot's later "Formatted Code!" commit skipped the file it couldn't parse.) The first commit is a **whitespace-only re-indent** of `lightrail` back into the class — verified AST-identical to the committed block, zero logic change.

## Verification

- Parse: `import hk_bus_eta` fails on master with `IndentationError`; succeeds on this branch. The `lightrail` re-indent is AST-identical to the block on master (parsed standalone), i.e. provably whitespace-only.
- `busStopRemark` fix: ran `HKEta.lrtfeeder` against the real captured K18 payload (the one attached with the original group report; same fixture as the npm PR) with `requests` mocked —
  - suspended stop `K18-U020` → remark now `"Service from this stop temporarily suspended or bus stop relocated. Please call the MTR Hotline 2881 8888…"` (was `""`),
  - normal stop `K18-D010` → remark unchanged (`""`), confirming no behaviour change for unaffected stops.
- Note: the live K18 suspension has since ended (stops restored 2026-07-10), so verification uses the captured payload rather than a live call — stated plainly rather than dressed as a live repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code), reviewed by evnchn
