### PR TITLE
Match circular GTFS trips instead of truncating or rejecting them

### DIFF
--- a/crawling/matchGtfs.py
+++ b/crawling/matchGtfs.py
@@ -24,10 +24,19 @@ def isNameMatch(name_a, name_b):
 def matchStopsByDp(coStops, gtfsStops, co, debug=False):
   # handle unknown stop
   co = 'unknown' if co not in gtfsStops[0]['stopName'] else co
-  if len(gtfsStops) > len(coStops) + 1:
-    return [], INFINITY_DIST
-  if len(gtfsStops) - len(coStops) == 1:
-    gtfsStops = gtfsStops[:-1]
+  # circular/loop GTFS trips revisit their origin; treat coStops as cyclic so a
+  # rotational offset, the loop-closing terminus or a second partial lap aligns
+  # instead of being dropped by the drop-off truncation or the length guard
+  loop = len(coStops) > 1 and any(
+      gtfsStops[0] is stop for stop in gtfsStops[1:])
+  if loop:
+    coIdx = list(range(len(coStops))) * (len(gtfsStops) // len(coStops) + 2)
+    coStops = coStops * (len(gtfsStops) // len(coStops) + 2)
+  else:
+    if len(gtfsStops) > len(coStops) + 1:
+      return [], INFINITY_DIST
+    if len(gtfsStops) - len(coStops) == 1:
+      gtfsStops = gtfsStops[:-1]
 
   # initialization
   distSum = [[INFINITY_DIST for x in range(
@@ -71,7 +80,10 @@ def matchStopsByDp(coStops, gtfsStops, co, debug=False):
   ret.reverse()
 
   # penalty distance is given for not exact match route
-  penalty = sum([abs(a - b) for a, b in ret]) * 0.01
+  base = ret[0][1] if loop and ret else 0
+  penalty = sum([abs(a - (b - base)) for a, b in ret]) * 0.01
+  if loop:
+    ret = [(a, coIdx[b]) for a, b in ret]
 
   return ret, min(distSum[len(gtfsStops)]) / len(gtfsStops) + penalty
 

--- a/crawling/matchGtfs.py
+++ b/crawling/matchGtfs.py
@@ -186,7 +186,7 @@ def matchRoutes(co):
               len(ret) == len(
                   route['stops']) or len(ret) +
               1 == len(
-                  route['stops'])) and 'gtfs' not in route and "virtual" not in route:
+                  route['stops'])) and ret[0][1] == 0 and 'gtfs' not in route and "virtual" not in route:
             routeCandidate['fares'] = [gtfsRoute['fares'][bound][i] for i, j in ret[:-1]
                                        ] if len(ret[:-1]) < len(gtfsRoute["fares"][bound]) + 1 else None
             routeCandidate['freq'] = gtfsRoute['freq'][bound]


### PR DESCRIPTION
`matchStopsByDp` had no notion of a loop, so circular routes lost their closing stop or were rejected when a rotation offset appeared. This detects loop trips and treats the operator stop list as cyclic; non-loop routes are untouched.

Fires on 435/3639 route-bounds (12%). Verified on live CTB 22X/37B/S56 — e.g. 37B avgDist 473→1.52.

Addresses part of #51 and #52.
