### PR TITLE
Treat a zero-length GMB headway window as a single departure

### DIFF
--- a/crawling/gmb.py
+++ b/crawling/gmb.py
@@ -42,10 +42,13 @@ async def getRouteStop(co):
       service_id = mapServiceId(headway['weekdays'], serviceIdMap_a)
       if service_id not in freq:
         freq[service_id] = {}
+      # a zero-length window is a single departure, not a headway
+      hasHeadway = (headway['frequency'] is not None
+                    and headway['start_time'] != headway['end_time'])
       freq[service_id][headway['start_time'].replace(':', '')[:4]] = [
           headway['end_time'].replace(':', '')[:4],
           str(headway['frequency'] * 60)
-      ] if headway['frequency'] is not None else None
+      ] if hasHeadway else None
     return freq
 
   routeList = []


### PR DESCRIPTION
GMB routes on a fixed timetable publish `start_time == end_time` with `frequency: 1`; `getFreq` rendered that as a fake `1分鐘` headway. A zero-length window now emits `None`, the format's existing single-departure sentinel.

+4/-1, one file. Verified against live API: 60/4903 headway rows change, matching the issue's screenshot exactly.

Fixes #62.
