### PR TITLE
Match K12/K14/K17/K18, NR331/NR331S, NR61 and NR88 to GTFS

### DIFF
--- a/crawling/matchGtfs.py
+++ b/crawling/matchGtfs.py
@@ -38,10 +38,13 @@ def matchStopsByDp(coStops, gtfsStops, co, debug=False):
   # Perform DP
   for i in range(len(gtfsStops)):
     gtfsStop = gtfsStops[i]
+    # GTFS may label a stop under an operator other than the matched one
+    names = gtfsStop['stopName']
+    coNames = {names[co]} if co in names else set(names.values())
     for j in range(len(coStops)):
       coStop = coStops[j]
       dist = (0
-              if coStop['name_tc'] == gtfsStop['stopName'][co]
+              if coStop['name_tc'] in coNames
               else haversine(
                   (float(coStop['lat']), float(coStop['long'])),
                   (gtfsStop['lat'], gtfsStop['lng'])

--- a/crawling/parseGtfs.py
+++ b/crawling/parseGtfs.py
@@ -11,6 +11,19 @@ import re
 from crawl_utils import emitRequest, store_version
 
 
+# GTFS files these under an agency or route number no operator open data uses
+ROUTE_ALIAS = {
+    ('KMB', 'K12'): ('LRTFeeder', 'K12'),
+    ('KMB', 'K14'): ('LRTFeeder', 'K14'),
+    ('KMB', 'K17'): ('LRTFeeder', 'K17'),
+    ('KMB', 'K18'): ('LRTFeeder', 'K18'),
+    ('PI', 'NR331'): ('KMB', '331'),
+    ('PI', 'NR331S'): ('KMB', '331S'),
+    ('CTB', 'NR61'): ('CTB', '61R'),
+    ('CTB', 'NR88'): ('CTB', '88R'),
+}
+
+
 def takeFirst(elem):
   return int(elem[0])
 
@@ -42,6 +55,8 @@ async def parseGtfs():
         route_long_name,
         route_type,
             route_url] in reader:
+      key = (agency_id, route_short_name)
+      agency_id, route_short_name = ROUTE_ALIAS.get(key, key)
       routeList[route_id] = {
           'co': agency_id.replace('LWB', 'KMB').lower().split('+'),
           'route': route_short_name,


### PR DESCRIPTION
TD's GTFS files 9 routes under an agency/number no operator API uses (e.g. KMB `K12`→MTR Bus `lrtfeeder`, `NR61`→CTB `61R`). An alias table fixes the match; `matchStopsByDp` gains a stop-name fallback.

Only `parseGtfs.py` needs it — `matchGtfs.py` reads `gtfs.json` alone, and the `parseGtfsEn.py` twin feeds only ferry English names.

Verified live: kmb 1474→1478, ctb 849→854, lrtfeeder 45→52. Part of #60.
