### PR TITLE
fix: graceful handling for 'not exist' stops instead of filtering them out

### DIFF
--- a/crawling/kmb.py
+++ b/crawling/kmb.py
@@ -30,8 +30,7 @@ async def getRouteStop():
   def isStopExist(stopId):
     if stopId not in stopList:
       print("Not exist stop: ", stopId, file=sys.stderr)
-      # Create a placeholder entry for non-existent stops
-      # Location is near Hong Kong (not Null Island) as per issue #67
+      # placeholder near Hong Kong, not Null Island, so the stop stays in place
       stopList[stopId] = {
           'stop': stopId,
           'name_tc': '沒有車站資料',

--- a/crawling/kmb.py
+++ b/crawling/kmb.py
@@ -30,7 +30,16 @@ async def getRouteStop():
   def isStopExist(stopId):
     if stopId not in stopList:
       print("Not exist stop: ", stopId, file=sys.stderr)
-    return stopId in stopList
+      # Create a placeholder entry for non-existent stops
+      # Location is near Hong Kong (not Null Island) as per issue #67
+      stopList[stopId] = {
+          'stop': stopId,
+          'name_tc': '沒有車站資料',
+          'name_en': 'Stop information not available',
+          'lat': '22.30000',
+          'long': '114.17000'
+      }
+    return True
 
   # load route list and stop list if exist
   routeList = {}

--- a/crawling/kmb.py
+++ b/crawling/kmb.py
@@ -27,7 +27,7 @@ async def getRouteStop():
     for stop in _stopList:
       stopList[stop['stop']] = stop
 
-  def isStopExist(stopId):
+  def addPlaceholderStop(stopId):
     if stopId not in stopList:
       print("Not exist stop: ", stopId, file=sys.stderr)
       # placeholder near Hong Kong, not Null Island, so the stop stays in place
@@ -38,7 +38,6 @@ async def getRouteStop():
           'lat': '22.30000',
           'long': '114.17000'
       }
-    return True
 
   # load route list and stop list if exist
   routeList = {}
@@ -71,8 +70,9 @@ async def getRouteStop():
     for routeKey in routeList.keys():
       stops = [routeList[routeKey]['stops'][seq]
                for seq in sorted(routeList[routeKey]['stops'].keys())]
-      # filter non-exist stops
-      stops = list(filter(isStopExist, stops))
+      # keep stops KMB does not publish, with a placeholder entry
+      for stopId in stops:
+        addPlaceholderStop(stopId)
       routeList[routeKey]['stops'] = stops
 
     # flatten the routeList back to array


### PR DESCRIPTION
KMB sometimes returns a stop ID missing from their database (e.g. `1AB800949FF1203B` on 278K); the crawler silently filtered it out of the route, leaving a gap.

`isStopExist` now inserts a placeholder (`沒有車站資料`, near-HK coords) instead, so the stop stays in the route with a clear unavailable marker.

+10/-1, one file. Fixes #67.
