### PR TITLE
Add midday crawl pass to self-heal missed 05:10 window

### DIFF
--- a/.github/workflows/fetch-data.yml
+++ b/.github/workflows/fetch-data.yml
@@ -4,7 +4,7 @@ on:
       # branches-ignore:
       #   - alpha
   schedule:
-    - cron: "10 9,21 * * *" # 05:10 and 17:10 (HKT) daily
+    - cron: "10 3,9,21 * * *" # 11:10, 17:10 and 05:10 (HKT) daily; extra midday pass self-heals a missed 05:10 window in ~6h instead of ~12h
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Add a midday crawl at 11:10 HKT so a missed 05:10 window self-heals in ~6h instead of ~12h.

Measured: 95/95 scheduled runs over 46 days started >10min late (median ~88min, p90 177min, worst 410min) — GitHub's queue delay already dwarfs the 10-min publish margin.

One-line cron change; does not touch the 05:10/17:10 anchor times.
