### PR TITLE
Restore the GTFS id on the one-way legs a virtual circular route consumes

### DIFF
--- a/crawling/matchGtfs.py
+++ b/crawling/matchGtfs.py
@@ -130,8 +130,7 @@ def matchRoutes(co):
 
   routeCandidates = []
   # a virtual circular route is built from the two real one-way routes of the
-  # same route number, so a match against it is also a match for both of them.
-  # a route number can match more than one GTFS route, so keep the closest.
+  # same number, so its match is also theirs; keep the closest of several.
   circularGtfs = {}
   # one pass to find matches of co vs gtfs by DP
   for gtfsId, gtfsRoute in gtfsRoutes.items():
@@ -223,8 +222,7 @@ def matchRoutes(co):
   for route in routeList:
     if 'gtfs' not in route:
       route['co'] = [co]
-      # the virtual circular route that consumed this route number matched
-      # GTFS; this leg is part of that route, so it carries the same id
+      # this leg is part of the virtual circular route that matched, so same id
       if route['route'] in circularGtfs:
         route['gtfs'] = [circularGtfs[route['route']][0]]
 

--- a/crawling/matchGtfs.py
+++ b/crawling/matchGtfs.py
@@ -130,7 +130,8 @@ def matchRoutes(co):
 
   routeCandidates = []
   # a virtual circular route is built from the two real one-way routes of the
-  # same route number, so a match against it is also a match for both of them
+  # same route number, so a match against it is also a match for both of them.
+  # a route number can match more than one GTFS route, so keep the closest.
   circularGtfs = {}
   # one pass to find matches of co vs gtfs by DP
   for gtfsId, gtfsRoute in gtfsRoutes.items():
@@ -204,8 +205,10 @@ def matchRoutes(co):
             routeCandidate['gtfs'] = [gtfsId]
             # mark the route has mapped to GTFS, mainly for ctb routes
             route['found'] = True
-          if "virtual" in route:
-            circularGtfs.setdefault(route['route'], gtfsId)
+          if "virtual" in route and (
+                  route['route'] not in circularGtfs
+                  or bestMatch[1] < circularGtfs[route['route']][1]):
+            circularGtfs[route['route']] = (gtfsId, bestMatch[1])
           routeCandidates.append(routeCandidate)
           if '_route' not in gtfsRoute:
             gtfsRoute['_route'] = {}
@@ -223,7 +226,7 @@ def matchRoutes(co):
       # the virtual circular route that consumed this route number matched
       # GTFS; this leg is part of that route, so it carries the same id
       if route['route'] in circularGtfs:
-        route['gtfs'] = [circularGtfs[route['route']]]
+        route['gtfs'] = [circularGtfs[route['route']][0]]
 
   print(co,
         len([route for route in routeList if 'gtfs' not in route]),

--- a/crawling/matchGtfs.py
+++ b/crawling/matchGtfs.py
@@ -129,6 +129,9 @@ def matchRoutes(co):
     stopList = json.load(f)
 
   routeCandidates = []
+  # a virtual circular route is built from the two real one-way routes of the
+  # same route number, so a match against it is also a match for both of them
+  circularGtfs = {}
   # one pass to find matches of co vs gtfs by DP
   for gtfsId, gtfsRoute in gtfsRoutes.items():
     debug = False and gtfsId == '1047' and gtfsRoute['orig']['zh'] == '沙田站'
@@ -201,6 +204,8 @@ def matchRoutes(co):
             routeCandidate['gtfs'] = [gtfsId]
             # mark the route has mapped to GTFS, mainly for ctb routes
             route['found'] = True
+          if "virtual" in route:
+            circularGtfs.setdefault(route['route'], gtfsId)
           routeCandidates.append(routeCandidate)
           if '_route' not in gtfsRoute:
             gtfsRoute['_route'] = {}
@@ -215,6 +220,10 @@ def matchRoutes(co):
   for route in routeList:
     if 'gtfs' not in route:
       route['co'] = [co]
+      # the virtual circular route that consumed this route number matched
+      # GTFS; this leg is part of that route, so it carries the same id
+      if route['route'] in circularGtfs:
+        route['gtfs'] = [circularGtfs[route['route']]]
 
   print(co,
         len([route for route in routeList if 'gtfs' not in route]),


### PR DESCRIPTION
62 route-directions ship `gtfsId: null` because a synthetic circular route wins the match over the two real one-way routes it was built from, and only the winner keeps the id — so these draw a straight line (e.g. CTB 170 往沙田站).

Nine lines give the id back: 62 legs gain an id, 0 change, 0 lost.

Scope: 39 still have no waypoints file, `fares`/`freq`/`jt` stay null, and 170's line can be briefly worse until the next waypoints crawl.
