### PR TITLE
Refuse to write an empty NLB route or stop list

### DIFF
--- a/crawling/nlb.py
+++ b/crawling/nlb.py
@@ -80,6 +80,10 @@ async def getRouteStop(co):
 
   await getRouteStopList()
 
+  if not routeList or not stopList:
+    raise Exception(f"empty payload: {len(routeList)} routes, "
+                    f"{len(stopList)} stops")
+
   with open(ROUTE_LIST, 'w', encoding='UTF-8') as rf, open(STOP_LIST, 'w', encoding='UTF-8') as sf:
     json.dump(routeList, rf, ensure_ascii=False)
     json.dump(stopList, sf, ensure_ascii=False)


### PR DESCRIPTION
`nlb.py` writes `routeList.nlb.json`/`stopList.nlb.json` unconditionally, so a well-formed 200 with an empty list parses fine and ships an empty NLB dataset with a new MD5 — CI stays green. Every other bad-response class already aborts; only empty-but-valid JSON slips through.

4 lines: raise if either list is empty. Verified: fails without fix, passes with it; live crawl unaffected (64 routes).
