### PR TITLE
Fix: Validate CTB stop lat/long before storing

### DIFF
--- a/crawling/ctb.py
+++ b/crawling/ctb.py
@@ -83,8 +83,8 @@ async def getRouteStop(co):
     except (ValueError, TypeError):
       stopList.pop(stopId, None)
       logger.warning(
-          "Stop %s has invalid lat/long: lat=%s, long=%s, skipping",
-          stopId, stopInfo.get('lat'), stopInfo.get('long'))
+          f"Stop {stopId} has invalid lat/long: "
+          f"lat={stopInfo.get('lat')}, long={stopInfo.get('long')}, skipping")
       continue
     stopList[stopId] = stopInfo
 

--- a/crawling/ctb.py
+++ b/crawling/ctb.py
@@ -72,6 +72,23 @@ async def getRouteStop(co):
 
   stopInfos = list(zip(_stops, await getStopList(_stops)))
   for stopId, stopInfo in stopInfos:
+    # Validate that the stop has parseable lat/long before storing.
+    # The Citybus API sometimes returns empty or incomplete stop records
+    # (e.g. {"data": {}} or missing lat/long fields), which later cause
+    # float() conversion failures in mergeRoutes.py.
+    if not stopInfo:
+      stopList.pop(stopId, None)
+      logger.warning(f"Stop {stopId} has empty data, skipping")
+      continue
+    try:
+      float(stopInfo.get('lat', ''))
+      float(stopInfo.get('long', ''))
+    except (ValueError, TypeError):
+      stopList.pop(stopId, None)
+      logger.warning(
+          "Stop %s has invalid lat/long: lat=%s, long=%s, skipping",
+          stopId, stopInfo.get('lat'), stopInfo.get('long'))
+      continue
     stopList[stopId] = stopInfo
 
   _routeList = []
@@ -80,7 +97,10 @@ async def getRouteStop(co):
       _routeList.append(route)
       continue
     for bound in ['inbound', 'outbound']:
-      if len(route['stops'][bound]) > 0:
+      stops = [
+          stopId for stopId in route['stops'][bound]
+          if stopId in stopList and bool(stopList[stopId])]
+      if len(stops) > 0:
         _routeList.append({
             'co': co,
             'route': route['route'],
@@ -89,7 +109,7 @@ async def getRouteStop(co):
             'orig_tc': route['orig_tc'] if bound == 'outbound' else route['dest_tc'],
             'dest_en': route['dest_en'] if bound == 'outbound' else route['orig_en'],
             'dest_tc': route['dest_tc'] if bound == 'outbound' else route['orig_tc'],
-            'stops': list(filter(lambda stopId: bool(stopList[stopId]), route['stops'][bound])),
+            'stops': stops,
             'serviceType': 0
         })
 

--- a/crawling/ctb.py
+++ b/crawling/ctb.py
@@ -72,10 +72,7 @@ async def getRouteStop(co):
 
   stopInfos = list(zip(_stops, await getStopList(_stops)))
   for stopId, stopInfo in stopInfos:
-    # Validate that the stop has parseable lat/long before storing.
-    # The Citybus API sometimes returns empty or incomplete stop records
-    # (e.g. {"data": {}} or missing lat/long fields), which later cause
-    # float() conversion failures in mergeRoutes.py.
+    # incomplete records (e.g. {"data": {}}) later break float() in mergeRoutes
     if not stopInfo:
       stopList.pop(stopId, None)
       logger.warning(f"Stop {stopId} has empty data, skipping")


### PR DESCRIPTION
Citybus sometimes returns stops with empty/invalid payloads (missing or unparseable `lat`/`long`), which later crash `mergeRoutes.py`'s `float()` conversion as "Problematic stop" (e.g. stops 003978, 001883...).

Now: reject records unless both coords parse as floats, drop stale cached entries, skip a bound if no valid stops remain.

Verified against a real crawl artifact: 2584→2583 stops, 0 problematic. Fixes #74.
